### PR TITLE
Add the ability to specify endpoint types.

### DIFF
--- a/serverless.js
+++ b/serverless.js
@@ -20,7 +20,8 @@ const {
 const defaults = {
   region: 'us-east-1',
   stage: 'dev',
-  description: 'Serverless Components API'
+  description: 'Serverless Components API',
+  endpointTypes: ['EDGE']
 }
 
 class AwsApiGateway extends Component {
@@ -31,7 +32,7 @@ class AwsApiGateway extends Component {
 
     config.name = this.state.name || this.context.resourceId()
 
-    const { name, description, region, stage } = config
+    const { name, description, region, stage, endpointTypes } = config
 
     this.context.debug(`Starting API Gateway deployment with name ${name} in the ${region} region`)
 
@@ -52,7 +53,7 @@ class AwsApiGateway extends Component {
 
     if (!apiId) {
       this.context.debug(`API ID not found in state. Creating a new API.`)
-      apiId = await createApi({ apig, name, description })
+      apiId = await createApi({ apig, name, description, endpointTypes })
       this.context.debug(`API with ID ${apiId} created.`)
       this.state.id = apiId
       await this.save()

--- a/utils.js
+++ b/utils.js
@@ -12,11 +12,14 @@ const apiExists = async ({ apig, apiId }) => {
   }
 }
 
-const createApi = async ({ apig, name, description }) => {
+const createApi = async ({ apig, name, description, endpointTypes }) => {
   const api = await apig
     .createRestApi({
       name,
-      description
+      description,
+      endpointConfiguration: {
+        types: endpointTypes
+      }
     })
     .promise()
 
@@ -261,9 +264,9 @@ const createIntegration = async ({ apig, lambda, apiId, endpoint }) => {
     restApiId: apiId,
     type: isLambda ? 'AWS_PROXY' : 'HTTP_PROXY',
     integrationHttpMethod: 'POST',
-    uri: (isLambda
+    uri: isLambda
       ? `arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${endpoint.function}/invocations`
-      : endpoint.proxyURI)
+      : endpoint.proxyURI
   }
 
   try {


### PR DESCRIPTION
This PR adds the ability to specify endpoint configuration types as discussed in #11.
I added the default `[ 'EDGE' ]` type to the `defaults` so the new parameter `endpointTypes` is optional.

Let me know if you have any ideas/requests, I'd be glad to update this PR :)