### PR TITLE
Retry TooManyRequestsException on deployment and endpoint validation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "license": "Apache",
   "dependencies": {
     "@serverless/core": "^1.0.0",
-    "aws-sdk": "^2.0.0"
+    "aws-sdk": "^2.0.0",
+    "p-retry": "^4.1.0"
   },
   "devDependencies": {
     "babel-eslint": "9.0.0",

--- a/serverless.js
+++ b/serverless.js
@@ -1,5 +1,4 @@
 const AWS = require('aws-sdk')
-const pRetry = require('p-retry')
 const { Component, utils } = require('@serverless/core')
 
 const {
@@ -15,7 +14,8 @@ const {
   removeMethods,
   removeAuthorizers,
   removeResources,
-  removeOutdatedEndpoints
+  removeOutdatedEndpoints,
+  retry
 } = require('./utils')
 
 const defaults = {
@@ -108,16 +108,7 @@ class AwsApiGateway extends Component {
       `Creating deployment for API ID ${apiId} in the ${stage} stage and the ${region} region.`
     )
 
-    await pRetry(() => createDeployment({ apig, apiId, stage }), {
-      retries: 5,
-      minTimeout: 1000,
-      factor: 2,
-      onFailedAttempt: (error) => {
-        this.context.debug(
-          `[WARNING] Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`
-        )
-      }
-    })
+    await retry(() => createDeployment({ apig, apiId, stage }))
 
     config.url = `https://${apiId}.execute-api.${region}.amazonaws.com/${stage}`
 


### PR DESCRIPTION
This PR implements a solution discussed in #8 for both deployment issues and endpoint creation issues (@volkancoskun).

At this point, there are no debug logs about retrying since functions from utils do not have access to `this`, and I didn't want to pass the context through the entire execution chain. 

@eahefnawy please review! This is basically the same solution I suggested in the issue, I just extracted the `retry` helper function so it can be used across the package.